### PR TITLE
Dice updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 results/*
 !results/.gitkeep 
 temp
+.venv

--- a/pages/02_case.py
+++ b/pages/02_case.py
@@ -188,7 +188,7 @@ def display_citations(citations: list[str]):
     st.caption(citations_string)
 
 
-@st.experimental_dialog("Are you done with the case?")  # type: ignore
+@st.experimental_dialog("Are you sure you want to move on to the next case?")  # type: ignore
 def dialog_case_done():
     if st.button("Yes", type="primary"):
 

--- a/pages/02_case.py
+++ b/pages/02_case.py
@@ -121,7 +121,16 @@ def display_hypothesis_input(group: Group, key: str):
 
 
 def on_hypotheses_change():
-    st.toast("Hypotheses updated!")
+    # Get the current hypotheses table from session state
+    hypotheses_table = st.session_state["hypotheses_table"]
+    
+    # Sort the added_rows if they exist
+    if "added_rows" in hypotheses_table and hypotheses_table["added_rows"]:
+        sorted_rows = sorted(hypotheses_table["added_rows"], key=lambda x: x["hypothesis"].lower())
+        hypotheses_table["added_rows"] = sorted_rows
+
+    #st.toast("Hypotheses updated!")
+    st.toast("Hypotheses updated and alphabetically sorted!")
 
 
 def display_ai_help(group: Group, case_description: str, hypotheses_table: dict):

--- a/pages/02_case.py
+++ b/pages/02_case.py
@@ -222,11 +222,19 @@ col1, col2 = st.columns([0.3, 0.7])
 with col1:
     hypotheses_df = display_hypothesis_input(get_group(), key="hypotheses_table")
 with col2:
-    display_ai_help(
-        get_group(),
-        get_case_description(get_case_index()),
-        st.session_state["hypotheses_table"],
-    )
+    if get_group() is Group.RECOMMENDATIONS_DRIVEN:
+        if st.button("See AI Recommendations"): # only show recommendations when the button is pressed
+            display_ai_help(
+                get_group(),
+                get_case_description(get_case_index()),
+                st.session_state["hypotheses_table"],
+            )
+    else:
+        display_ai_help(
+            get_group(),
+            get_case_description(get_case_index()),
+            st.session_state["hypotheses_table"],
+        )
 
 # Because the case description depends on the AI message - because of
 # citations - we need to compute it after the AI message.

--- a/utils.py
+++ b/utils.py
@@ -141,7 +141,7 @@ def parse_message(
                 parsed_message += f" :red-background[[{citations.index(c) + 1}]]"
             parsed_message += "\n\n"
 
-        parsed_message += f"**Evidence against {hypotheses[0]}**\n\n"
+        parsed_message += f"**Evidence against {selected_hypotheses[0]}**\n\n"
         for e in message_dict["evidence_against"]:
             parsed_message += f"- {e['claim']}"
             for c in e["citations"]:

--- a/utils.py
+++ b/utils.py
@@ -242,8 +242,10 @@ Take your time to do the task correctly and think things through step by step.
 
 Answer using a JSON format.
 
+Case description:
 {case_description}
 
+Diagnostic hypotheses:
 {"\n".join(hypotheses)}
 """.strip()
 
@@ -272,8 +274,10 @@ Take your time to do the task correctly and think things through step by step.
 
 Answer using a JSON format.
 
+Case description:
 {case_description}
 
+Diagnostic hypotheses:
 {"\n".join(hypotheses)}
 """.strip()
 
@@ -298,7 +302,7 @@ def gen_json_schema_for_recommendation_driven() -> Dict[str, Any]:
             "properties": {
                 "rationale": {
                     "type": "string",
-                    "description": "Your rationale for the diagnosis you provided, citing the case description to support your claims.",
+                    "description": "Your rationale for the lead_diagnosis you selected, citing the case description to support your claims.",
                 },
                 "citations": {
                     "type": "array",
@@ -307,7 +311,7 @@ def gen_json_schema_for_recommendation_driven() -> Dict[str, Any]:
                 },
                 "lead_diagnosis": {
                     "type": "string",
-                    "description": "The diagnosis you believe is most likely based on the evidence presented.",
+                    "description": "The diagnosis you believe is most likely based on the evidence presented, strictly chosen from the list of hypotheses provided.",
                 },
             },
             "required": ["lead_diagnosis", "citations", "rationale"],


### PR DESCRIPTION
Hey Antoine, I've added the following:

- fixed prompt for Recommendation driven to make sure it strictly chooses the lead diagnosis from the user generated hypotheses
- alphabetically reorder the hypotheses in session_state every time the hypotheses are updated (note: **I've kept the order on the interface as is, since the clinicians would probably want to see it in the order they typed**)
- add a "See AI recommendation" button before seeing the AI results in Recommendation driven

Please check that I haven't messed up anything 👋